### PR TITLE
Add option to only show summary messages in Chat window

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -1779,19 +1779,19 @@ function Core:SetAttendanceValues(upcomingEvent, inviteInfo, inviteIndex)
 end
 
 function Core:EventAttendanceProcessCompleted(upcomingEvent, closeAfterEnd)
-	GOW.Logger:Debug("Event attendances process completed: " .. upcomingEvent.titleWithKey);
+	GOW.Logger:Debug("Event attendances process completed: " .. upcomingEvent.titleWithKey, true);
 
 	if (not processedEvents:contains(upcomingEvent.titleWithKey)) then
 		processedEvents:push(upcomingEvent.titleWithKey);
 
 		if (isNewEventBeingCreated) then
-			GOW.Logger:PrintSuccessMessage("New event is successfully created: " .. upcomingEvent.titleWithKey);
+			GOW.Logger:PrintSuccessMessage("New event is successfully created: " .. upcomingEvent.titleWithKey, false);
 			isNewEventBeingCreated = false;
 			if (containerFrame:IsShown()) then
 				Core:CreateUpcomingEvents();
 			end
 		elseif (not isEventProcessCompleted) then
-			GOW.Logger:PrintMessage("Event RSVP process completed: " .. upcomingEvent.titleWithKey);
+			GOW.Logger:PrintMessage("Event RSVP process completed: " .. upcomingEvent.titleWithKey, false);
 		end
 	end
 
@@ -2035,7 +2035,7 @@ function Core:InitializeEventInvites()
 			if (GOW.DB.profile.guilds[guildKey].eventsRefreshTime and ns.UPCOMING_EVENTS.exportTime and ns.UPCOMING_EVENTS.exportTime < GOW.DB.profile.guilds[guildKey].eventsRefreshTime) then
 				isEventProcessCompleted = true;
 
-				GOW.Logger:PrintMessage("The most recently imported data has already been processed, the RSVP synchronization will be skipped...");
+				GOW.Logger:PrintMessage("The most recently imported data has already been processed, the RSVP synchronization will be skipped...", true);
 			else
 				GOW.Logger:Debug("Event attendance initial process started!");
 

--- a/Logger.lua
+++ b/Logger.lua
@@ -8,8 +8,11 @@ function Logger:Debug(msg)
     end
 end
 
-function Logger:PrintMessage(msg)
-    print(Logger:GetColoredStringWithBranding("ffcc00", msg));
+function Logger:PrintMessage(msg, isSummary)
+    if GOW.DB and GOW.DB.profile and GOW.DB.profile.onlyShowSummary and not isSummary then
+        return
+    end
+    print(Logger:GetColoredStringWithBranding("ffcc00", msg))
 end
 
 function Logger:PrintSuccessMessage(msg)

--- a/Options.lua
+++ b/Options.lua
@@ -41,9 +41,17 @@ local optionsTable = {
                         GOW.DB.profile.warnNewEvents = value;
                     end,
                 },
+		onlyShowSummary = {
+    			name = "Only show summary after event invites",
+    			desc = "Suppresses per-event processing messages in chat",
+    			type = "toggle",
+    			order = 3,
+    			get = function() return GOW.DB.profile.onlyShowSummary end,
+    			set = function(_, val) GOW.DB.profile.onlyShowSummary = val end,
+		},
                 HideInCombat = {
                     type = "toggle",
-                    order = 3,
+                    order = 4,
                     name = "Hide in combat",
                     desc = "Hide the Guilds of WoW window when entering combat.",
                     width = "full",

--- a/Options.lua
+++ b/Options.lua
@@ -42,9 +42,10 @@ local optionsTable = {
                     end,
                 },
 		onlyShowSummary = {
-    			name = "Only show summary after event invites",
+    			name = "Only show summary for calendar updates",
     			desc = "Suppresses per-event processing messages in chat",
     			type = "toggle",
+			width = "full",
     			order = 3,
     			get = function() return GOW.DB.profile.onlyShowSummary end,
     			set = function(_, val) GOW.DB.profile.onlyShowSummary = val end,


### PR DESCRIPTION
The addon  was filling my chat window with these "Guilds of WoW: Event RSVP process completed: Liberation of Undermi-GoW474411 " and then it did Guilds of WoW: Event invites have been completed. Number of events processed: 9 and then if there was nothing to update it did Guilds of WoW: The most recently imported data has already been processed, the RSVP synchronization will be skipped...

So I have added a checkbox in the options to only show the summaries ie Guilds of WoW: Event invites have been completed. Number of events processed: 9 or Guilds of WoW: The most recently imported data has already been processed, the RSVP synchronization will be skipped...