### PR TITLE
Add option to reduce event notifications

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -15,6 +15,7 @@ GOW.defaults = {
 	profile = {
 		version = 1,
 		minimap = { hide = false },
+		reduceEventNotifications = true,
 		warnNewEvents = true,
 		hideInCombat = true,
 	}
@@ -1790,7 +1791,7 @@ function Core:EventAttendanceProcessCompleted(upcomingEvent, closeAfterEnd)
 			if (containerFrame:IsShown()) then
 				Core:CreateUpcomingEvents();
 			end
-		elseif (not isEventProcessCompleted) then
+		elseif (not isEventProcessCompleted and not GOW.DB.profile.reduceEventNotifications) then
 			GOW.Logger:PrintMessage("Event RSVP process completed: " .. upcomingEvent.titleWithKey);
 		end
 	end
@@ -2035,7 +2036,9 @@ function Core:InitializeEventInvites()
 			if (GOW.DB.profile.guilds[guildKey].eventsRefreshTime and ns.UPCOMING_EVENTS.exportTime and ns.UPCOMING_EVENTS.exportTime < GOW.DB.profile.guilds[guildKey].eventsRefreshTime) then
 				isEventProcessCompleted = true;
 
-				GOW.Logger:PrintMessage("The most recently imported data has already been processed, the RSVP synchronization will be skipped...");
+				if (not GOW.DB.profile.reduceEventNotifications) then
+					GOW.Logger:PrintMessage("The most recently imported data has already been processed, the RSVP synchronization will be skipped...");
+				end
 			else
 				GOW.Logger:Debug("Event attendance initial process started!");
 

--- a/Options.lua
+++ b/Options.lua
@@ -41,9 +41,18 @@ local optionsTable = {
                         GOW.DB.profile.warnNewEvents = value;
                     end,
                 },
-                HideInCombat = {
+                reduceEventNotifications = {
                     type = "toggle",
                     order = 3,
+                    name = "Reduce event notifications",
+                    desc = "Show only important event notifications in chat.",
+                    width = "full",
+                    get = function() return GOW.DB.profile.reduceEventNotifications end,
+                    set = function(_, val) GOW.DB.profile.reduceEventNotifications = val end,
+                },
+                HideInCombat = {
+                    type = "toggle",
+                    order = 4,
                     name = "Hide in combat",
                     desc = "Hide the Guilds of WoW window when entering combat.",
                     width = "full",


### PR DESCRIPTION
Introduces a 'Reduce event notifications' toggle in the options, allowing users to limit event-related chat messages to only important notifications. Updates logic in Core.lua to respect this setting and suppress less critical event messages when enabled.