### PR TITLE
Add officer notes w/ colorized tooltip to RCLC voting frame

### DIFF
--- a/GoWWishlists.lua
+++ b/GoWWishlists.lua
@@ -70,7 +70,6 @@ function GoWWishlists:GetCurrentCharacterInfo()
         realmNormalized = realmNormalized,
         regionId = regionId,
         nameLower = name:lower(),
-        nameNormalized = GOW.Helper:StripDiacritics(name),
         realmLower = realmNormalized:lower(),
     };
 end
@@ -95,10 +94,10 @@ function GoWWishlists:BuildWishlistIndex()
     local personalLists = ns.WISHLISTS.personalWishlists;
     if personalLists then
         for _, charEntry in ipairs(personalLists) do
-            local entryName = charEntry.name and GOW.Helper:StripDiacritics(charEntry.name) or "";
+            local entryName = charEntry.name and charEntry.name:lower() or "";
             local entryRealm = charEntry.realmNameNormalized and charEntry.realmNameNormalized:lower() or "";
 
-            if isDebug or (entryName == charInfo.nameNormalized and entryRealm == charInfo.realmLower) then
+            if isDebug or (entryName == charInfo.nameLower and entryRealm == charInfo.realmLower) then
                 self.state.hasPersonalWishlistEntry = true;
                 for _, item in ipairs(charEntry.wishlist) do
                     item.characterName = entryName;

--- a/GoWWishlists.lua
+++ b/GoWWishlists.lua
@@ -70,6 +70,7 @@ function GoWWishlists:GetCurrentCharacterInfo()
         realmNormalized = realmNormalized,
         regionId = regionId,
         nameLower = name:lower(),
+        nameNormalized = GOW.Helper:StripDiacritics(name),
         realmLower = realmNormalized:lower(),
     };
 end
@@ -94,10 +95,10 @@ function GoWWishlists:BuildWishlistIndex()
     local personalLists = ns.WISHLISTS.personalWishlists;
     if personalLists then
         for _, charEntry in ipairs(personalLists) do
-            local entryName = charEntry.name and charEntry.name:lower() or "";
+            local entryName = charEntry.name and GOW.Helper:StripDiacritics(charEntry.name) or "";
             local entryRealm = charEntry.realmNameNormalized and charEntry.realmNameNormalized:lower() or "";
 
-            if isDebug or (entryName == charInfo.nameLower and entryRealm == charInfo.realmLower) then
+            if isDebug or (entryName == charInfo.nameNormalized and entryRealm == charInfo.realmLower) then
                 self.state.hasPersonalWishlistEntry = true;
                 for _, item in ipairs(charEntry.wishlist) do
                     item.characterName = entryName;

--- a/GoWWishlists.lua
+++ b/GoWWishlists.lua
@@ -123,6 +123,8 @@ function GoWWishlists:BuildWishlistIndex()
             self.state.guildWishlistData = guildLists[1];
         else
             local playerGuild, _, _, playerGuildRealm = GetGuildInfo("player");
+            -- GetGuildInfo returns nil for realm when guild is on the player's own realm
+            playerGuildRealm = playerGuildRealm or charInfo.realmNormalized;
             if playerGuild then
                 for _, guildEntry in ipairs(guildLists) do
                     if guildEntry.guild == playerGuild and guildEntry.guildRegionId == charInfo.regionId and guildEntry.guildRealmNormalized == playerGuildRealm then

--- a/GoWWishlists.lua
+++ b/GoWWishlists.lua
@@ -125,8 +125,7 @@ function GoWWishlists:BuildWishlistIndex()
             local playerGuild = GetGuildInfo("player");
             if playerGuild then
                 for _, guildEntry in ipairs(guildLists) do
-                    local guildRealm = guildEntry.guildRealmNormalized and guildEntry.guildRealmNormalized:lower() or "";
-                    if guildEntry.guild == playerGuild and guildRealm == charInfo.realmLower then
+                    if guildEntry.guild == playerGuild and guildEntry.guildRegionId == charInfo.regionId then
                         self.state.guildWishlistData = guildEntry;
                         break;
                     end

--- a/GoWWishlists.lua
+++ b/GoWWishlists.lua
@@ -122,10 +122,10 @@ function GoWWishlists:BuildWishlistIndex()
         if isDebug and #guildLists > 0 then
             self.state.guildWishlistData = guildLists[1];
         else
-            local playerGuild = GetGuildInfo("player");
+            local playerGuild, _, _, playerGuildRealm = GetGuildInfo("player");
             if playerGuild then
                 for _, guildEntry in ipairs(guildLists) do
-                    if guildEntry.guild == playerGuild and guildEntry.guildRegionId == charInfo.regionId then
+                    if guildEntry.guild == playerGuild and guildEntry.guildRegionId == charInfo.regionId and guildEntry.guildRealmNormalized == playerGuildRealm then
                         self.state.guildWishlistData = guildEntry;
                         break;
                     end

--- a/Helper.lua
+++ b/Helper.lua
@@ -1,4 +1,4 @@
-local Helper = {}
+Helper = {}
 Helper.__index = Helper
 
 local GOW = GuildsOfWow or {};
@@ -57,29 +57,6 @@ end
 
 function Helper:IsKeystonesEnabled()
     return WOW_PROJECT_ID == WOW_PROJECT_MAINLINE;
-end
-
-local diacriticMap = {
-    ["À"]="A",["Á"]="A",["Â"]="A",["Ã"]="A",["Ä"]="A",["Å"]="A",
-    ["à"]="a",["á"]="a",["â"]="a",["ã"]="a",["ä"]="a",["å"]="a",
-    ["È"]="E",["É"]="E",["Ê"]="E",["Ë"]="E",
-    ["è"]="e",["é"]="e",["ê"]="e",["ë"]="e",
-    ["Ì"]="I",["Í"]="I",["Î"]="I",["Ï"]="I",
-    ["ì"]="i",["í"]="i",["î"]="i",["ï"]="i",
-    ["Ò"]="O",["Ó"]="O",["Ô"]="O",["Õ"]="O",["Ö"]="O",
-    ["ò"]="o",["ó"]="o",["ô"]="o",["õ"]="o",["ö"]="o",
-    ["Ù"]="U",["Ú"]="U",["Û"]="U",["Ü"]="U",
-    ["ù"]="u",["ú"]="u",["û"]="u",["ü"]="u",
-    ["Ñ"]="N",["ñ"]="n",["Ç"]="C",["ç"]="c",["Ÿ"]="Y",["ÿ"]="y",
-};
-
-function Helper:StripDiacritics(str)
-    if not str then return "" end
-    -- Match 2-byte UTF-8 sequences (covers all accented Latin characters)
-    local result = str:gsub("[\192-\223][\128-\191]", function(c)
-        return diacriticMap[c] or c;
-    end);
-    return result:lower();
 end
 
 function Helper:GetCurrentCharacterUniqueKey()

--- a/Helper.lua
+++ b/Helper.lua
@@ -1,4 +1,4 @@
-Helper = {}
+local Helper = {}
 Helper.__index = Helper
 
 local GOW = GuildsOfWow or {};
@@ -57,6 +57,29 @@ end
 
 function Helper:IsKeystonesEnabled()
     return WOW_PROJECT_ID == WOW_PROJECT_MAINLINE;
+end
+
+local diacriticMap = {
+    ["À"]="A",["Á"]="A",["Â"]="A",["Ã"]="A",["Ä"]="A",["Å"]="A",
+    ["à"]="a",["á"]="a",["â"]="a",["ã"]="a",["ä"]="a",["å"]="a",
+    ["È"]="E",["É"]="E",["Ê"]="E",["Ë"]="E",
+    ["è"]="e",["é"]="e",["ê"]="e",["ë"]="e",
+    ["Ì"]="I",["Í"]="I",["Î"]="I",["Ï"]="I",
+    ["ì"]="i",["í"]="i",["î"]="i",["ï"]="i",
+    ["Ò"]="O",["Ó"]="O",["Ô"]="O",["Õ"]="O",["Ö"]="O",
+    ["ò"]="o",["ó"]="o",["ô"]="o",["õ"]="o",["ö"]="o",
+    ["Ù"]="U",["Ú"]="U",["Û"]="U",["Ü"]="U",
+    ["ù"]="u",["ú"]="u",["û"]="u",["ü"]="u",
+    ["Ñ"]="N",["ñ"]="n",["Ç"]="C",["ç"]="c",["Ÿ"]="Y",["ÿ"]="y",
+};
+
+function Helper:StripDiacritics(str)
+    if not str then return "" end
+    -- Match 2-byte UTF-8 sequences (covers all accented Latin characters)
+    local result = str:gsub("[\192-\223][\128-\191]", function(c)
+        return diacriticMap[c] or c;
+    end);
+    return result:lower();
 end
 
 function Helper:GetCurrentCharacterUniqueKey()

--- a/Helper.lua
+++ b/Helper.lua
@@ -1,4 +1,4 @@
-Helper = {}
+local Helper = {}
 Helper.__index = Helper
 
 local GOW = GuildsOfWow or {};

--- a/rclc/core.lua
+++ b/rclc/core.lua
@@ -57,7 +57,7 @@ function RCGoW:GetPlayerWish(itemId, playerFullName)
     local matches = {};
 
     for _, charEntry in ipairs(data.wishlists) do
-        local nameMatch = GOW.Helper:StripDiacritics(charEntry.name) == GOW.Helper:StripDiacritics(playerName);
+        local nameMatch = charEntry.name == playerName;
         local realmMatch = not playerRealm
             or (charEntry.realmName and charEntry.realmName:gsub("%s", "") == playerRealm);
         if nameMatch and realmMatch then

--- a/rclc/core.lua
+++ b/rclc/core.lua
@@ -57,7 +57,7 @@ function RCGoW:GetPlayerWish(itemId, playerFullName)
     local matches = {};
 
     for _, charEntry in ipairs(data.wishlists) do
-        local nameMatch = charEntry.name == playerName;
+        local nameMatch = GOW.Helper:StripDiacritics(charEntry.name) == GOW.Helper:StripDiacritics(playerName);
         local realmMatch = not playerRealm
             or (charEntry.realmName and charEntry.realmName:gsub("%s", "") == playerRealm);
         if nameMatch and realmMatch then

--- a/rclc/core.lua
+++ b/rclc/core.lua
@@ -18,6 +18,7 @@ local function GetDebugWish()
         tag = tag,
         difficulty = "Mythic",
         notes = "Debug: fake wishlist entry",
+        officerNotes = "Officer: debug officer note",
         gain = { percent = pct, stat = math.random(50, 800), metric = "DPS" },
         isCatalystItem = isCatalyst or nil,
         catalystItemId = isCatalyst and 249991 or nil,

--- a/rclc/lootFrame.lua
+++ b/rclc/lootFrame.lua
@@ -64,7 +64,7 @@ local function OnEntryRefreshed(entry)
 
     -- Add tooltip overlay for GoW wish info
     if not entry._gowTipFrame then
-        local tipFrame = CreateFrame("Frame", nil, entry);
+        local tipFrame = CreateFrame("Frame", nil, entry.itemLvl:GetParent());
         tipFrame:SetPoint("TOPLEFT", entry.itemLvl, "TOPLEFT", 0, 0);
         tipFrame:SetPoint("BOTTOMRIGHT", entry.itemLvl, "BOTTOMRIGHT", 0, 0);
         tipFrame:EnableMouse(true);

--- a/rclc/votingFrame.lua
+++ b/rclc/votingFrame.lua
@@ -94,7 +94,11 @@ local function RenderWishCell(rowFrame, cellFrame, data, cols, row, realRow, col
     end
     if wish.notes and wish.notes ~= "" then
         tinsert(tipLines, " ");
-        tinsert(tipLines, "Note: " .. wish.notes);
+        tinsert(tipLines, "|cff00ff00Note:|r " .. wish.notes);
+    end
+    if wish.officerNotes and wish.officerNotes ~= "" then
+        tinsert(tipLines, " ");
+        tinsert(tipLines, "|cffff8000Officer Note:|r " .. wish.officerNotes);
     end
     cellFrame._gowTip = #tipLines > 0 and tipLines or nil;
 

--- a/wishlists/guild.lua
+++ b/wishlists/guild.lua
@@ -994,7 +994,7 @@ function GoWWishlists:CollectObtainedItems(characterName, realmName, rosterMembe
         end
 
         if passRoster then
-            local match = not characterName or (charEntry.name == characterName and charEntry.realmName == realmName);
+            local match = not characterName or (GOW.Helper:StripDiacritics(charEntry.name) == GOW.Helper:StripDiacritics(characterName) and charEntry.realmName == realmName);
             if match then
                 for _, item in ipairs(charEntry.wishlist) do
                     if item.isObtained then
@@ -1231,7 +1231,7 @@ function GoWWishlists:PopulateGuildPlayerDetail(detailPanel, member, guildRealm)
     local seenBosses = {};
     if self.state.guildWishlistData and self.state.guildWishlistData.wishlists then
         for _, charEntry in ipairs(self.state.guildWishlistData.wishlists) do
-            if charEntry.name == member.characterName and charEntry.realmName == member.realmName then
+            if GOW.Helper:StripDiacritics(charEntry.name) == GOW.Helper:StripDiacritics(member.characterName) and charEntry.realmName == member.realmName then
                 for _, item in ipairs(charEntry.wishlist) do
                     if not item.isObtained then
                         table.insert(allMemberItems, item);

--- a/wishlists/guild.lua
+++ b/wishlists/guild.lua
@@ -994,7 +994,7 @@ function GoWWishlists:CollectObtainedItems(characterName, realmName, rosterMembe
         end
 
         if passRoster then
-            local match = not characterName or (GOW.Helper:StripDiacritics(charEntry.name) == GOW.Helper:StripDiacritics(characterName) and charEntry.realmName == realmName);
+            local match = not characterName or (charEntry.name == characterName and charEntry.realmName == realmName);
             if match then
                 for _, item in ipairs(charEntry.wishlist) do
                     if item.isObtained then
@@ -1231,7 +1231,7 @@ function GoWWishlists:PopulateGuildPlayerDetail(detailPanel, member, guildRealm)
     local seenBosses = {};
     if self.state.guildWishlistData and self.state.guildWishlistData.wishlists then
         for _, charEntry in ipairs(self.state.guildWishlistData.wishlists) do
-            if GOW.Helper:StripDiacritics(charEntry.name) == GOW.Helper:StripDiacritics(member.characterName) and charEntry.realmName == member.realmName then
+            if charEntry.name == member.characterName and charEntry.realmName == member.realmName then
                 for _, item in ipairs(charEntry.wishlist) do
                     if not item.isObtained then
                         table.insert(allMemberItems, item);


### PR DESCRIPTION
This pull request enhances the display capabilities of wishlist entries, especially around note handling and tooltip overlays. The most important changes are grouped below:

**Tooltip and UI Enhancements:**

* Bug Fix: Updated the tooltip overlay in `lootFrame.lua` so that the tooltip frame is now attached to the parent of `itemLvl`, ensuring correct positioning and event handling.
* Improved the rendering of wishlist notes in `votingFrame.lua` by color-coding regular notes in green and adding a distinct orange-colored "Officer Note" section when available.