### PR TITLE
Create token badge functionality and improve UI precision

### DIFF
--- a/GoWWishlists.lua
+++ b/GoWWishlists.lua
@@ -249,12 +249,12 @@ GoWWishlists.constants.SLOT_LABELS = {
     ["INVTYPE_FEET"] = "Feet",
     ["INVTYPE_WRIST"] = "Wrist",
     ["INVTYPE_HAND"] = "Hands",
-    ["INVTYPE_FINGER"] = "Ring",
+    ["INVTYPE_FINGER"] = "Finger",
     ["INVTYPE_TRINKET"] = "Trinket",
     ["INVTYPE_CLOAK"] = "Back",
     ["INVTYPE_WEAPONMAINHAND"] = "Main Hand",
-    ["INVTYPE_WEAPONOFFHAND"] = "Off-Hand",
-    ["INVTYPE_HOLDABLE"] = "Off-Hand",
+    ["INVTYPE_WEAPONOFFHAND"] = "Off Hand",
+    ["INVTYPE_HOLDABLE"] = "Off Hand",
     ["INVTYPE_RANGED"] = "Ranged",
     ["INVTYPE_2HWEAPON"] = "Two-Hand",
     ["INVTYPE_WEAPON"] = "One-Hand",
@@ -262,7 +262,7 @@ GoWWishlists.constants.SLOT_LABELS = {
 
 GoWWishlists.constants.SLOT_ORDER = {
     "INVTYPE_HEAD", "INVTYPE_NECK", "INVTYPE_SHOULDER",
-    "INVTYPE_CHEST", "INVTYPE_ROBE", "INVTYPE_WAIST",
+    "INVTYPE_CHEST", "INVTYPE_WAIST",
     "INVTYPE_LEGS", "INVTYPE_FEET", "INVTYPE_WRIST",
     "INVTYPE_HAND", "INVTYPE_FINGER", "INVTYPE_TRINKET",
     "INVTYPE_CLOAK", "INVTYPE_WEAPONMAINHAND",
@@ -798,17 +798,17 @@ end
 
 function GoWWishlists:CreateTokenBadge(parent)
     local badge = L:CreateTextBadge(parent, {
-        text = "|cfff5c542TOKEN|r",
-        height = 16, minWidth = 38, paddingX = 4,
-        bgR = 0.12, bgG = 0.10, bgB = 0.02, bgA = 0.85,
-        borderR = 0.96, borderG = 0.77, borderB = 0.26, borderA = 0.6,
+        text = "|cffa335eeT|r",
+        height = 16, minWidth = 20, paddingX = 4,
+        bgR = 0.08, bgG = 0.02, bgB = 0.12, bgA = 0.85,
+        borderR = 0.64, borderG = 0.21, borderB = 0.93, borderA = 0.6,
     });
     badge:SetHeight(16);
 
     badge:EnableMouse(true);
     badge:SetScript("OnEnter", function(self)
         GameTooltip:SetOwner(self, "ANCHOR_RIGHT");
-        GameTooltip:AddLine("Token Item", 0.96, 0.77, 0.26);
+        GameTooltip:AddLine("Token Item", 0.64, 0.21, 0.93);
         local name = self.sourceItemName or (self.sourceItemId and C_Item.GetItemInfo(self.sourceItemId));
         if name then
             GameTooltip:AddLine("Source: " .. name, 1, 1, 1);

--- a/GoWWishlists.lua
+++ b/GoWWishlists.lua
@@ -230,7 +230,7 @@ GoWWishlists.constants.TAG_DISPLAY = {
     BIS      = { label = "BiS", color = "25f478", tip = "Best in Slot" },
     NEED     = { label = "N",   color = "ff8000", tip = "Need" },
     GREED    = { label = "G",   color = "ffd700", tip = "Greed" },
-    MINOR    = { label = "M",   color = "6495ed", tip = "Minor Upgrade" },
+    MINOR    = { label = "MU",  color = "6495ed", tip = "Minor Upgrade" },
     TRANSMOG = { label = "T",   color = "ff69b4", tip = "Transmog" },
     OFFSPEC  = { label = "OS",  color = "a9a9a9", tip = "Off-Spec" },
 };
@@ -670,7 +670,7 @@ function GoWWishlists:UpdateGainBadge(badge, gain, prefix, report, isCatalystIte
     local hasGain = false;
     if gain and gain.percent and gain.percent > 0 then
         local metric = (gain.metric and gain.metric ~= "") and gain.metric or "DPS";
-        badge.text:SetText("|cff00ff00" .. prefix .. string.format("%.1f", gain.percent) .. "%|r");
+        badge.text:SetText("|cff00ff00" .. prefix .. string.format("%.2f", gain.percent) .. "%|r");
         hasGain = true;
     elseif gain and gain.stat and gain.stat > 0 then
         badge.text:SetText("|cff00ff00" .. prefix .. string.format("%.1f", gain.stat) .. "|r");
@@ -689,7 +689,7 @@ function GoWWishlists:UpdateGainBadge(badge, gain, prefix, report, isCatalystIte
             if gain.stat and gain.stat > 0 then
                 statLine = string.format("+%.1f %s", gain.stat, metric);
             else
-                statLine = string.format("%.1f%% %s", gain.percent, metric);
+                statLine = string.format("%.2f%% %s", gain.percent, metric);
             end
             if isCatalystItem then
                 statLine = statLine .. " (Catalyst)";
@@ -728,7 +728,7 @@ function GoWWishlists:UpdateGainBadge(badge, gain, prefix, report, isCatalystIte
             local tipParts = {};
             if gain.percent and gain.percent > 0 then
                 local catalystSuffix = isCatalystItem and " (Catalyst)" or "";
-                table.insert(tipParts, string.format("%.1f%% %s%s", gain.percent, metric, catalystSuffix));
+                table.insert(tipParts, string.format("%.2f%% %s%s", gain.percent, metric, catalystSuffix));
             end
             if gain.stat and gain.stat > 0 then
                 table.insert(tipParts, "+" .. string.format("%.1f", gain.stat) .. " " .. metric);
@@ -794,6 +794,42 @@ end
 function GoWWishlists:UpdateCatalystBadge(badge, isCatalystItem)
     if not badge then return end
     badge:SetShown(isCatalystItem == true);
+end
+
+function GoWWishlists:CreateTokenBadge(parent)
+    local badge = L:CreateTextBadge(parent, {
+        text = "|cfff5c542TOKEN|r",
+        height = 16, minWidth = 38, paddingX = 4,
+        bgR = 0.12, bgG = 0.10, bgB = 0.02, bgA = 0.85,
+        borderR = 0.96, borderG = 0.77, borderB = 0.26, borderA = 0.6,
+    });
+    badge:SetHeight(16);
+
+    badge:EnableMouse(true);
+    badge:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_RIGHT");
+        GameTooltip:AddLine("Token Item", 0.96, 0.77, 0.26);
+        if self.sourceItemName then
+            GameTooltip:AddLine("Source: " .. self.sourceItemName, 1, 1, 1);
+        end
+        GameTooltip:Show();
+    end);
+    badge:SetScript("OnLeave", function() GameTooltip:Hide() end);
+
+    badge:Hide();
+    return badge;
+end
+
+function GoWWishlists:UpdateTokenBadge(badge, sourceItemId)
+    if not badge then return end
+    local hasToken = sourceItemId ~= nil and sourceItemId ~= "";
+    badge:SetShown(hasToken);
+    if hasToken then
+        local sourceItemName = C_Item.GetItemInfo(sourceItemId);
+        badge.sourceItemName = sourceItemName;
+    else
+        badge.sourceItemName = nil;
+    end
 end
 
 function GoWWishlists:FormatTag(tag)

--- a/GoWWishlists.lua
+++ b/GoWWishlists.lua
@@ -110,6 +110,12 @@ function GoWWishlists:BuildWishlistIndex()
                         local key = item.itemId;
                         self.state.wishlistIndex[key] = self.state.wishlistIndex[key] or {};
                         table.insert(self.state.wishlistIndex[key], item);
+
+                        if item.sourceItemId then
+                            local sourceKey = item.sourceItemId;
+                            self.state.wishlistIndex[sourceKey] = self.state.wishlistIndex[sourceKey] or {};
+                            table.insert(self.state.wishlistIndex[sourceKey], item);
+                        end
                     end
                 end
                 if not isDebug then break end
@@ -798,17 +804,17 @@ end
 
 function GoWWishlists:CreateTokenBadge(parent)
     local badge = L:CreateTextBadge(parent, {
-        text = "|cffa335eeT|r",
-        height = 16, minWidth = 20, paddingX = 4,
-        bgR = 0.08, bgG = 0.02, bgB = 0.12, bgA = 0.85,
-        borderR = 0.64, borderG = 0.21, borderB = 0.93, borderA = 0.6,
+        text = "|cffb968f0T|r",
+        height = 16, minWidth = 16, paddingX = 0,
+        bgR = 0.10, bgG = 0.04, bgB = 0.14, bgA = 0.85,
+        borderR = 0.73, borderG = 0.41, borderB = 0.94, borderA = 0.6,
     });
-    badge:SetHeight(16);
+    badge:SetSize(16, 16);
 
     badge:EnableMouse(true);
     badge:SetScript("OnEnter", function(self)
         GameTooltip:SetOwner(self, "ANCHOR_RIGHT");
-        GameTooltip:AddLine("Token Item", 0.64, 0.21, 0.93);
+        GameTooltip:AddLine("Token Item", 0.73, 0.41, 0.94);
         local name = self.sourceItemName or (self.sourceItemId and C_Item.GetItemInfo(self.sourceItemId));
         if name then
             GameTooltip:AddLine("Source: " .. name, 1, 1, 1);

--- a/GoWWishlists.lua
+++ b/GoWWishlists.lua
@@ -809,8 +809,9 @@ function GoWWishlists:CreateTokenBadge(parent)
     badge:SetScript("OnEnter", function(self)
         GameTooltip:SetOwner(self, "ANCHOR_RIGHT");
         GameTooltip:AddLine("Token Item", 0.96, 0.77, 0.26);
-        if self.sourceItemName then
-            GameTooltip:AddLine("Source: " .. self.sourceItemName, 1, 1, 1);
+        local name = self.sourceItemName or (self.sourceItemId and C_Item.GetItemInfo(self.sourceItemId));
+        if name then
+            GameTooltip:AddLine("Source: " .. name, 1, 1, 1);
         end
         GameTooltip:Show();
     end);
@@ -824,9 +825,9 @@ function GoWWishlists:UpdateTokenBadge(badge, sourceItemId)
     if not badge then return end
     local hasToken = sourceItemId ~= nil and sourceItemId ~= "";
     badge:SetShown(hasToken);
+    badge.sourceItemId = hasToken and sourceItemId or nil;
     if hasToken then
-        local sourceItemName = C_Item.GetItemInfo(sourceItemId);
-        badge.sourceItemName = sourceItemName;
+        badge.sourceItemName = C_Item.GetItemInfo(sourceItemId);
     else
         badge.sourceItemName = nil;
     end

--- a/rclc/lootFrame.lua
+++ b/rclc/lootFrame.lua
@@ -50,7 +50,7 @@ local function OnEntryRefreshed(entry)
     local tagInfo = wish.tag and GoWWishlists.constants.TAG_DISPLAY[wish.tag];
     local label = tagInfo and string.format("|cff%s%s|r", tagInfo.color, tagInfo.tip) or "Wish";
     if wish.gain and wish.gain.percent and wish.gain.percent > 0 then
-        label = label .. string.format(" |cff00ff00%.1f%%|r", wish.gain.percent);
+        label = label .. string.format(" |cff00ff00%.2f%%|r", wish.gain.percent);
         if wish.gain.stat then
             label = label .. string.format(" |cff00ff00(%.1f %s)|r", wish.gain.stat, wish.gain.metric or "");
         end
@@ -87,7 +87,7 @@ local function OnEntryRefreshed(entry)
     if wish.gain then
         local metric = (wish.gain.metric and wish.gain.metric ~= "") and wish.gain.metric or "DPS";
         if wish.gain.percent and wish.gain.percent > 0 then
-            table.insert(tipLines, string.format("%.1f%% %s", wish.gain.percent, metric));
+            table.insert(tipLines, string.format("%.2f%% %s", wish.gain.percent, metric));
         end
         if wish.gain.stat and wish.gain.stat > 0 then
             table.insert(tipLines, string.format("%.1f %s (raw)", wish.gain.stat, metric));

--- a/rclc/votingFrame.lua
+++ b/rclc/votingFrame.lua
@@ -58,7 +58,7 @@ local function RenderWishCell(rowFrame, cellFrame, data, cols, row, realRow, col
     local mode = GetDisplayMode();
     if mode == "percent" then
         if wish.gain and wish.gain.percent and wish.gain.percent > 0 then
-            display = string.format("|cff00ff00%.1f%%|r", wish.gain.percent);
+            display = string.format("|cff00ff00%.2f%%|r", wish.gain.percent);
         end
     elseif mode == "value" then
         if wish.gain and wish.gain.stat and wish.gain.stat > 0 then
@@ -83,7 +83,7 @@ local function RenderWishCell(rowFrame, cellFrame, data, cols, row, realRow, col
     if wish.gain then
         local metric = (wish.gain.metric and wish.gain.metric ~= "") and wish.gain.metric or "DPS";
         if wish.gain.percent and wish.gain.percent > 0 then
-            tinsert(tipLines, string.format("%.1f%% %s", wish.gain.percent, metric));
+            tinsert(tipLines, string.format("%.2f%% %s", wish.gain.percent, metric));
         end
         if wish.gain.stat and wish.gain.stat > 0 then
             tinsert(tipLines, string.format("%.1f %s (raw)", wish.gain.stat, metric));

--- a/wishlists/events.lua
+++ b/wishlists/events.lua
@@ -126,6 +126,22 @@ function GoWWishlists:MarkWishlistObtained(itemId, difficulty)
                 end
             end
 
+            local crossKey = (entry.itemId == itemId) and entry.sourceItemId or entry.itemId;
+            if crossKey then
+                local crossList = self.state.wishlistIndex[crossKey];
+                if crossList then
+                    for j = #crossList, 1, -1 do
+                        if crossList[j] == entry then
+                            table.remove(crossList, j);
+                            break;
+                        end
+                    end
+                    if #crossList == 0 then
+                        self.state.wishlistIndex[crossKey] = nil;
+                    end
+                end
+            end
+
             return true;
         end
     end

--- a/wishlists/guild.lua
+++ b/wishlists/guild.lua
@@ -1271,6 +1271,7 @@ function GoWWishlists:PopulateGuildPlayerDetail(detailPanel, member, guildRealm)
     local seenSlots = {};
     for _, entry in ipairs(allMemberItems) do
         local _, _, _, equipLoc = C_Item.GetItemInfoInstant(entry.itemId);
+        if equipLoc == "INVTYPE_ROBE" then equipLoc = "INVTYPE_CHEST" end
         if equipLoc and equipLoc ~= "" then
             seenSlots[equipLoc] = true;
         end

--- a/wishlists/guild.lua
+++ b/wishlists/guild.lua
@@ -120,7 +120,8 @@ function GoWWishlists:CollectGuildWishlistByBoss(difficultyFilter, rosterMemberS
                         end
 
                         local boss = bossGroups[bossName];
-                        local itemKey = item.itemId .. "-" .. (item.difficulty or "");
+                        local sourceToken = item.sourceItemId and (":source:" .. item.sourceItemId) or "";
+                        local itemKey = item.itemId .. "-" .. (item.difficulty or "") .. sourceToken;
                         if not boss.items[itemKey] then
                             boss.items[itemKey] = {
                                 itemId = item.itemId,
@@ -128,6 +129,7 @@ function GoWWishlists:CollectGuildWishlistByBoss(difficultyFilter, rosterMemberS
                                 isTierSetPiece = item.isTierSetPiece,
                                 isCatalystItem = item.isCatalystItem,
                                 catalystItemId = item.catalystItemId,
+                                sourceItemId = item.sourceItemId,
                                 members = {},
                             };
                             table.insert(boss.itemOrder, itemKey);
@@ -190,6 +192,9 @@ function GoWWishlists:CreateGuildItemRow(parent)
     row.tierBadge = self:CreateTierBadge(row);
     row.tierBadge:SetPoint("RIGHT", row, "RIGHT", -6, 0);
 
+    row.tokenBadge = self:CreateTokenBadge(row);
+    row.tokenBadge:SetPoint("RIGHT", row, "RIGHT", -6, 0);
+
     local gainBadge = self:CreateGainBadge(row);
     gainBadge:SetPoint("RIGHT", row, "RIGHT", -6, 0);
     row.gainBadge = gainBadge;
@@ -234,14 +239,22 @@ function GoWWishlists:PopulateGuildItemRow(row, itemData)
     end
 
     self:UpdateTierBadge(row.tierBadge, itemData.isTierSetPiece);
+    self:UpdateTokenBadge(row.tokenBadge, itemData.sourceItemId);
 
     row.gainBadge:ClearAllPoints();
     local rightAnchor = row;
     local rightOffset = -6;
     local anchorPoint = "RIGHT";
+    if row.tokenBadge:IsShown() then
+        row.tokenBadge:ClearAllPoints();
+        row.tokenBadge:SetPoint("RIGHT", rightAnchor, "RIGHT", rightOffset, 0);
+        rightAnchor = row.tokenBadge;
+        anchorPoint = "LEFT";
+        rightOffset = -4;
+    end
     if row.tierBadge:IsShown() then
         row.tierBadge:ClearAllPoints();
-        row.tierBadge:SetPoint("RIGHT", rightAnchor, "RIGHT", rightOffset, 0);
+        row.tierBadge:SetPoint("RIGHT", rightAnchor, anchorPoint, rightOffset, 0);
         rightAnchor = row.tierBadge;
         anchorPoint = "LEFT";
         rightOffset = -4;

--- a/wishlists/guild.lua
+++ b/wishlists/guild.lua
@@ -568,6 +568,7 @@ function GoWWishlists:PopulateGuildWishlistView(frame)
     lootPanel.headerText:SetText("LOOT");
     detailPanel.headerText:SetText("WISHLIST");
     lootPanel.ownerFrame = frame;
+    detailPanel.ownerFrame = frame;
 
     local guildLootSortMode = NormalizeGuildLootSort(frame.guildLootSortMode);
     frame.guildLootSortMode = guildLootSortMode;
@@ -703,7 +704,11 @@ function GoWWishlists:PopulateGuildWishlistView(frame)
         frame.subtitleText:SetText(displayName .. "  |  " .. memberCount .. " members  |  " .. totalItems .. " items");
 
         self:PopulateSourcePanel(sourcePanel, bossOrder, bossCounts, function(selectedBoss)
+            frame.guildSelectedBoss = selectedBoss;
             self:PopulateGuildLootPanel(lootPanel, bossGroups, bossOrder, selectedBoss, guildRealm, detailPanel, bossToRaid, bossToJournalId, guildLootSortMode, guildHideObtained, rosterMemberSet);
+            if detailPanel._guildPlayerSourceFilter and detailPanel._activeMember then
+                self:PopulateGuildPlayerDetail(detailPanel, detailPanel._activeMember, detailPanel._activeGuildRealm);
+            end
         end, bossToRaid, bossToJournalId);
 
         self:PopulateGuildLootPanel(lootPanel, bossGroups, bossOrder, nil, guildRealm, detailPanel, bossToRaid, bossToJournalId, guildLootSortMode, guildHideObtained, rosterMemberSet);
@@ -1269,13 +1274,30 @@ function GoWWishlists:PopulateGuildPlayerDetail(detailPanel, member, guildRealm)
 
     local memberItems = {};
     local seenSlots = {};
+    local guildPlayerSourceFilter = detailPanel._guildPlayerSourceFilter;
+    if guildPlayerSourceFilter == nil then guildPlayerSourceFilter = (GOW.DB and GOW.DB.profile and GOW.DB.profile.wishlistGuildPlayerSourceFilter) or false end
+    detailPanel._guildPlayerSourceFilter = guildPlayerSourceFilter;
+    local ownerFrame = detailPanel.ownerFrame;
+    local sourceFilterDiff = ownerFrame and ownerFrame.guildDifficultyFilter or "All";
+    local sourceFilterBoss = ownerFrame and ownerFrame.guildSelectedBoss or nil;
     for _, entry in ipairs(allMemberItems) do
         local _, _, _, equipLoc = C_Item.GetItemInfoInstant(entry.itemId);
         if equipLoc == "INVTYPE_ROBE" then equipLoc = "INVTYPE_CHEST" end
         if equipLoc and equipLoc ~= "" then
             seenSlots[equipLoc] = true;
         end
-        if guildPlayerSlotFilter == "All" or equipLoc == guildPlayerSlotFilter then
+        local passFilter = (guildPlayerSlotFilter == "All" or equipLoc == guildPlayerSlotFilter);
+        if passFilter and guildPlayerSourceFilter then
+            if sourceFilterDiff ~= "All" and entry.difficulty ~= sourceFilterDiff then
+                passFilter = false;
+            end
+            if passFilter and sourceFilterBoss then
+                if entry.sourceBossName ~= sourceFilterBoss then
+                    passFilter = false;
+                end
+            end
+        end
+        if passFilter then
             table.insert(memberItems, entry);
         end
     end
@@ -1344,6 +1366,28 @@ function GoWWishlists:PopulateGuildPlayerDetail(detailPanel, member, guildRealm)
             rebuild();
         end);
     slotBtn:SetPoint("LEFT", sortBtn, "RIGHT", 4, 0);
+
+    local sourceFilterBtn = L:CreateSubFilterBtn(scrollChild, "Source", 48);
+    sourceFilterBtn:SetHeight(14);
+    sourceFilterBtn:SetPoint("LEFT", slotBtn, "RIGHT", 4, 0);
+    L:SetButtonActive(sourceFilterBtn, guildPlayerSourceFilter);
+
+    sourceFilterBtn:SetScript("OnEnter", function(btn)
+        GameTooltip:SetOwner(btn, "ANCHOR_TOP");
+        if guildPlayerSourceFilter then
+            GameTooltip:AddLine("Show All Sources", 1, 1, 1);
+        else
+            GameTooltip:AddLine("Show Current Source Only", 1, 1, 1);
+        end
+        GameTooltip:Show();
+    end);
+    sourceFilterBtn:SetScript("OnLeave", function() GameTooltip:Hide() end);
+
+    sourceFilterBtn:SetScript("OnClick", function()
+        detailPanel._guildPlayerSourceFilter = not detailPanel._guildPlayerSourceFilter;
+        if GOW.DB and GOW.DB.profile then GOW.DB.profile.wishlistGuildPlayerSourceFilter = detailPanel._guildPlayerSourceFilter end
+        rebuild();
+    end);
 
     yOffset = yOffset + 20;
 

--- a/wishlists/guild.lua
+++ b/wishlists/guild.lua
@@ -711,6 +711,7 @@ function GoWWishlists:PopulateGuildWishlistView(frame)
             end
         end, bossToRaid, bossToJournalId);
 
+        frame.guildSelectedBoss = nil;
         self:PopulateGuildLootPanel(lootPanel, bossGroups, bossOrder, nil, guildRealm, detailPanel, bossToRaid, bossToJournalId, guildLootSortMode, guildHideObtained, rosterMemberSet);
 
         if detailPanel._activeMember then

--- a/wishlists/personal.lua
+++ b/wishlists/personal.lua
@@ -143,6 +143,7 @@ function GoWWishlists:PopulatePersonalWishlistView(frame)
             local passFilter = (currentFilter == "All") or (entry.difficulty == currentFilter);
             if passFilter and detailSlotFilter ~= "All" then
                 local _, _, _, equipLoc = C_Item.GetItemInfoInstant(entry.itemId);
+                if equipLoc == "INVTYPE_ROBE" then equipLoc = "INVTYPE_CHEST" end
                 if equipLoc ~= detailSlotFilter then
                     passFilter = false;
                 end
@@ -274,6 +275,7 @@ function GoWWishlists:PopulatePersonalWishlistView(frame)
                 for _, entry in ipairs(self.state.allItems) do
                     if not entry.isObtained then
                         local _, _, _, equipLoc = C_Item.GetItemInfoInstant(entry.itemId);
+                        if equipLoc == "INVTYPE_ROBE" then equipLoc = "INVTYPE_CHEST" end
                         if equipLoc and equipLoc ~= "" then
                             seenSlots[equipLoc] = true;
                         end

--- a/wishlists/personal.lua
+++ b/wishlists/personal.lua
@@ -20,6 +20,9 @@ function GoWWishlists:PopulatePersonalWishlistView(frame)
     detailPanel.headerText:SetText("WISHLIST");
 
     local currentBoss = nil; -- nil = All Bosses
+    local detailSourceFilter = frame.detailSourceFilter;
+    if detailSourceFilter == nil then detailSourceFilter = (GOW.DB and GOW.DB.profile and GOW.DB.profile.wishlistPersonalSourceFilter) or false end
+    frame.detailSourceFilter = detailSourceFilter;
 
     local bossGroups, bossOrder, unknownItems, bossToRaid, bossToJournalId; 
     local populateLootPanel;
@@ -52,6 +55,9 @@ function GoWWishlists:PopulatePersonalWishlistView(frame)
             currentBoss = selectedBoss;
             if GOW.DB and GOW.DB.profile then GOW.DB.profile.wishlistSelectedBoss = selectedBoss end
             populateLootPanel(currentBoss);
+            if detailSourceFilter then
+                populateDetailPanel();
+            end
         end, bossToRaid, bossToJournalId);
 
         local savedBoss = GOW.DB and GOW.DB.profile and GOW.DB.profile.wishlistSelectedBoss or nil;
@@ -130,7 +136,6 @@ function GoWWishlists:PopulatePersonalWishlistView(frame)
     local detailSlotFilter = frame.detailSlotFilter or "All";
     local detailHideObtained = frame.detailHideObtained;
     if detailHideObtained == nil then detailHideObtained = true end
-
     populateDetailPanel = function()
         local scrollChild = detailPanel.scrollChild;
         self:ClearChildren(scrollChild);
@@ -141,6 +146,11 @@ function GoWWishlists:PopulatePersonalWishlistView(frame)
         local obtainedItems = {};
         for _, entry in ipairs(self.state.allItems) do
             local passFilter = (currentFilter == "All") or (entry.difficulty == currentFilter);
+            if passFilter and detailSourceFilter and currentBoss then
+                if entry.sourceBossName ~= currentBoss then
+                    passFilter = false;
+                end
+            end
             if passFilter and detailSlotFilter ~= "All" then
                 local _, _, _, equipLoc = C_Item.GetItemInfoInstant(entry.itemId);
                 if equipLoc == "INVTYPE_ROBE" then equipLoc = "INVTYPE_CHEST" end
@@ -344,12 +354,43 @@ function GoWWishlists:PopulatePersonalWishlistView(frame)
 
         detailPanel.updateObtainedBtn = updateObtainedBtn;
 
+        local sourceFilterBtn = L:CreateSubFilterBtn(detailPanel, "Source", 48);
+        sourceFilterBtn:SetHeight(14);
+        sourceFilterBtn:SetPoint("LEFT", obtainedBtn, "RIGHT", 4, 0);
+        detailPanel.sourceFilterBtn = sourceFilterBtn;
+
+        sourceFilterBtn:SetScript("OnEnter", function(btn)
+            GameTooltip:SetOwner(btn, "ANCHOR_TOP");
+            if detailSourceFilter then
+                GameTooltip:AddLine("Show All Sources", 1, 1, 1);
+            else
+                GameTooltip:AddLine("Show Current Source Only", 1, 1, 1);
+            end
+            GameTooltip:Show();
+        end);
+        sourceFilterBtn:SetScript("OnLeave", function() GameTooltip:Hide() end);
+
+        local function updateSourceFilterBtn()
+            L:SetButtonActive(sourceFilterBtn, detailSourceFilter);
+        end
+
+        sourceFilterBtn:SetScript("OnClick", function()
+            detailSourceFilter = not detailSourceFilter;
+            frame.detailSourceFilter = detailSourceFilter;
+            if GOW.DB and GOW.DB.profile then GOW.DB.profile.wishlistPersonalSourceFilter = detailSourceFilter end
+            updateSourceFilterBtn();
+            populateDetailPanel();
+        end);
+
+        detailPanel.updateSourceFilterBtn = updateSourceFilterBtn;
+
         detailPanel.scrollFrame:SetPoint("TOPLEFT", sortBtn, "BOTTOMLEFT", -4, -4);
     end
 
     detailPanel.updateSortLabel();
     detailPanel.updateSlotLabel();
     detailPanel.updateObtainedBtn();
+    detailPanel.updateSourceFilterBtn();
 
     self:SetupDifficultyDropdown(sourcePanel, function(diff)
         frame.personalDifficultyFilter = diff;

--- a/wishlists/ui.lua
+++ b/wishlists/ui.lua
@@ -81,6 +81,7 @@ function GoWWishlists:CreateWishlistCardRow(parent, options)
     row.noteIcon = self:CreateNoteIconButton(row, row, "Interface\\Buttons\\UI-GuildButton-PublicNote-Up", "Note", 0, 1, 0);
     row.catalystBadge = self:CreateCatalystBadge(inner);
     row.tierBadge = self:CreateTierBadge(inner);
+    row.tokenBadge = self:CreateTokenBadge(inner);
 
     L:CreateRowSeparator(row);
     row.highlight = L:CreateRowHighlight(row);
@@ -127,6 +128,7 @@ function GoWWishlists:PopulateItemRow(row, entry, itemLink)
     self:UpdateGainBadge(row.gainBadge, entry.gain, nil, entry.report, entry.isCatalystItem);
     self:UpdateTierBadge(row.tierBadge, entry.isTierSetPiece);
     self:UpdateCatalystBadge(row.catalystBadge, entry.isCatalystItem);
+    self:UpdateTokenBadge(row.tokenBadge, entry.sourceItemId);
 
     local rightAnchor = row;
     local rightOffset = -8;
@@ -150,6 +152,14 @@ function GoWWishlists:PopulateItemRow(row, entry, itemLink)
         row.tierBadge:ClearAllPoints();
         row.tierBadge:SetPoint("RIGHT", rightAnchor, anchorPoint, rightOffset, 0);
         row.tierBadge:SetPoint("BOTTOM", row.inner, "BOTTOM", 0, 2);
+        rightAnchor = row.tierBadge;
+        anchorPoint = "LEFT";
+        rightOffset = -2;
+    end
+    if row.tokenBadge:IsShown() then
+        row.tokenBadge:ClearAllPoints();
+        row.tokenBadge:SetPoint("RIGHT", rightAnchor, anchorPoint, rightOffset, 0);
+        row.tokenBadge:SetPoint("BOTTOM", row.inner, "BOTTOM", 0, 2);
     end
 end
 


### PR DESCRIPTION
This pull request introduces several improvements and new features to the wishlist system, focusing on better handling of token/source items, enhanced filtering options in the UI, and consistency in gain percentage formatting. The most important changes are outlined below.

### Token/Source Item Support

* Added support for indexing wishlist entries by both `itemId` and `sourceItemId`, ensuring that token-based items and their sources are properly linked and managed in the wishlist index. (`GoWWishlists.lua`, `BuildWishlistIndex`, `MarkWishlistObtained`) [[1]](diffhunk://#diff-a6724b251625dbb4617326c7043c179035db2fd7b200bb3f8b6ef40f37137a19R113-R118) [[2]](diffhunk://#diff-3354f5960d2fc771e54335135ee39921475087e21790274536c94e1aee761450R129-R144)
* Introduced a new Token badge with tooltip support, and updated the guild loot UI to display this badge when relevant. (`GoWWishlists.lua`, `wishlists/guild.lua`) [[1]](diffhunk://#diff-a6724b251625dbb4617326c7043c179035db2fd7b200bb3f8b6ef40f37137a19R805-R841) [[2]](diffhunk://#diff-d0dc1f2a3063350103f9ea69e757bfb1f924cc928f34511029b5c3c72572b8f7R195-R197) [[3]](diffhunk://#diff-d0dc1f2a3063350103f9ea69e757bfb1f924cc928f34511029b5c3c72572b8f7R242-R257)
* Modified the guild wishlist aggregation logic to include `sourceItemId` in item keys and item data, improving differentiation and display for token items. (`wishlists/guild.lua`)

### UI Filtering Enhancements

* Added a "Source" filter button to the guild player detail panel, allowing users to filter wishlist entries by the currently selected boss and difficulty. Also, added a similar filter for the personal wishlist view. (`wishlists/guild.lua`, `wishlists/personal.lua`) [[1]](diffhunk://#diff-d0dc1f2a3063350103f9ea69e757bfb1f924cc928f34511029b5c3c72572b8f7R1278-R1301) [[2]](diffhunk://#diff-d0dc1f2a3063350103f9ea69e757bfb1f924cc928f34511029b5c3c72572b8f7R1371-R1392) [[3]](diffhunk://#diff-80c8776b446da67e572c8112d9c56ed4da3b26fa2728ff767e7c11a69216851cR23-R25) [[4]](diffhunk://#diff-80c8776b446da67e572c8112d9c56ed4da3b26fa2728ff767e7c11a69216851cR58-R60) [[5]](diffhunk://#diff-80c8776b446da67e572c8112d9c56ed4da3b26fa2728ff767e7c11a69216851cR149-R156)

### Gain Percentage Formatting Consistency

* Updated all UI displays and tooltips to show gain percentages with two decimal places for improved clarity and consistency. (`GoWWishlists.lua`, `rclc/lootFrame.lua`, `rclc/votingFrame.lua`) [[1]](diffhunk://#diff-a6724b251625dbb4617326c7043c179035db2fd7b200bb3f8b6ef40f37137a19L673-R679) [[2]](diffhunk://#diff-a6724b251625dbb4617326c7043c179035db2fd7b200bb3f8b6ef40f37137a19L692-R698) [[3]](diffhunk://#diff-a6724b251625dbb4617326c7043c179035db2fd7b200bb3f8b6ef40f37137a19L731-R737) [[4]](diffhunk://#diff-1967309d4ab62c8c99067c6696dc1e315c66978e3e172a49401eef548fd424a9L53-R53) [[5]](diffhunk://#diff-1967309d4ab62c8c99067c6696dc1e315c66978e3e172a49401eef548fd424a9L90-R90) [[6]](diffhunk://#diff-7b01fec460d329c71ca26a775899a6b93a0558f51eb699aae651f591cb2807c1L61-R61) [[7]](diffhunk://#diff-7b01fec460d329c71ca26a775899a6b93a0558f51eb699aae651f591cb2807c1L86-R86)

### UI/Label Improvements

* Updated slot and tag labels for clarity (e.g., "Ring" → "Finger", "Off-Hand" → "Off Hand", "M" → "MU" for Minor Upgrade). (`GoWWishlists.lua`) [[1]](diffhunk://#diff-a6724b251625dbb4617326c7043c179035db2fd7b200bb3f8b6ef40f37137a19L233-R239) [[2]](diffhunk://#diff-a6724b251625dbb4617326c7043c179035db2fd7b200bb3f8b6ef40f37137a19L252-R271)

### Miscellaneous

* Fixed minor UI bugs, such as ensuring the correct owner frame is set for detail panels and handling of "INVTYPE_ROBE" as "INVTYPE_CHEST" in filters. (`wishlists/guild.lua`, `wishlists/personal.lua`) [[1]](diffhunk://#diff-d0dc1f2a3063350103f9ea69e757bfb1f924cc928f34511029b5c3c72572b8f7R571) [[2]](diffhunk://#diff-80c8776b446da67e572c8112d9c56ed4da3b26fa2728ff767e7c11a69216851cR149-R156)

These changes collectively improve the accuracy, usability, and clarity of the wishlist system, especially for raids with token-based loot and for users who want more granular filtering options.