### PR TITLE
Add toggle for gain display mode and update UI accordingly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 db/
 db/*
 .vscode/
+.github/

--- a/Core.lua
+++ b/Core.lua
@@ -27,6 +27,7 @@ GOW.defaults = {
 		wishlistInfoFramePos = nil,
 		wishlistBrowserFramePos = nil,
 		wishlistCompactMode = false,
+		gainDisplayMode = "percent",
 		guildRosterFilter = "all",
 	}
 }
@@ -96,6 +97,7 @@ function GOW:OnInitialize()
 	isEventProcessCompleted = GOW.Helper:IsInGameCalendarAccessible() == false; -- if calendar is not accessible, consider event process completed to avoid blocking the app
 
 	local consoleCommandFunc = function(msg, editbox)
+		msg = strlower(msg);
 		if (msg == "minimap") then
 			Core:ToggleMinimap();
 		elseif (msg == "loot" and GOW.Helper:IsWishlistsEnabled()) then

--- a/GoWWishlists.lua
+++ b/GoWWishlists.lua
@@ -764,14 +764,13 @@ function GoWWishlists:UpdateGainBadge(badge, gain, prefix, report, isCatalystIte
             -- Fallback: simple tooltip — always show both values
             badge.tooltipLines = nil;
             local tipParts = {};
+            local catalystSuffix = isCatalystItem and " (Catalyst)" or "";
             if gain.stat and gain.stat > 0 and gain.percent and gain.percent > 0 then
-                local catalystSuffix = isCatalystItem and " (Catalyst)" or "";
                 table.insert(tipParts, string.format("+%s %s (%.2f%%)%s", self:FormatStatGain(gain.stat), metric, gain.percent, catalystSuffix));
             elseif gain.percent and gain.percent > 0 then
-                local catalystSuffix = isCatalystItem and " (Catalyst)" or "";
                 table.insert(tipParts, string.format("%.2f%% %s%s", gain.percent, metric, catalystSuffix));
             elseif gain.stat and gain.stat > 0 then
-                table.insert(tipParts, "+" .. self:FormatStatGain(gain.stat) .. " " .. metric);
+                table.insert(tipParts, string.format("+%s %s%s", self:FormatStatGain(gain.stat), metric, catalystSuffix));
             end
             badge.tooltipText = #tipParts > 0 and table.concat(tipParts, "\n") or nil;
         end

--- a/GoWWishlists.lua
+++ b/GoWWishlists.lua
@@ -445,6 +445,9 @@ function GoWWishlists:RefreshWishlistViews()
     if browserFrame and browserFrame.compactBtn and browserFrame.compactBtn.UpdateState then
         browserFrame.compactBtn:UpdateState();
     end
+    if browserFrame and browserFrame.gainDisplayBtn and browserFrame.gainDisplayBtn.UpdateState then
+        browserFrame.gainDisplayBtn:UpdateState();
+    end
     if browserFrame and browserFrame:IsShown() and browserFrame.SetActiveTab then
         browserFrame.SetActiveTab(browserFrame.activeTab or 1);
     end
@@ -452,6 +455,9 @@ function GoWWishlists:RefreshWishlistViews()
     local coreWishlists = self.frames.coreWishlists;
     if coreWishlists and coreWishlists.compactBtn and coreWishlists.compactBtn.UpdateState then
         coreWishlists.compactBtn:UpdateState();
+    end
+    if coreWishlists and coreWishlists.gainDisplayBtn and coreWishlists.gainDisplayBtn.UpdateState then
+        coreWishlists.gainDisplayBtn:UpdateState();
     end
     if coreWishlists and coreWishlists:IsShown() then
         if coreWishlists.RefreshContent then
@@ -493,6 +499,26 @@ function GoWWishlists:ToggleCompactMode()
         GOW.DB.profile.wishlistCompactMode = self.state.compactMode;
     end
     self:RefreshWishlistViews();
+end
+
+function GoWWishlists:ToggleGainDisplayMode()
+    self.state.gainDisplayMode = self.state.gainDisplayMode == "percent" and "raw" or "percent";
+    if GOW.DB and GOW.DB.profile then
+        GOW.DB.profile.gainDisplayMode = self.state.gainDisplayMode;
+    end
+    self:RefreshWishlistViews();
+end
+
+function GoWWishlists:GetGainValue(gain)
+    if not gain then return 0 end
+    if self.state.gainDisplayMode == "raw" then
+        return (gain.stat and gain.stat > 0) and gain.stat or (gain.percent or 0);
+    end
+    return (gain.percent and gain.percent > 0) and gain.percent or 0;
+end
+
+function GoWWishlists:FormatStatGain(n)
+    return tostring(math.floor(n + 0.5));
 end
 
 function GoWWishlists:GroupAndSortBosses(bossOrder, bossToRaid, bossToJournalId)
@@ -675,11 +701,15 @@ function GoWWishlists:UpdateGainBadge(badge, gain, prefix, report, isCatalystIte
 
     local hasGain = false;
     if gain and gain.percent and gain.percent > 0 then
-        local metric = (gain.metric and gain.metric ~= "") and gain.metric or "DPS";
-        badge.text:SetText("|cff00ff00" .. prefix .. string.format("%.2f", gain.percent) .. "%|r");
+        local isRawMode = self.state.gainDisplayMode == "raw";
+        if isRawMode and gain.stat and gain.stat > 0 then
+            badge.text:SetText("|cff00ff00" .. prefix .. "+" .. self:FormatStatGain(gain.stat) .. "|r");
+        else
+            badge.text:SetText("|cff00ff00" .. prefix .. string.format("%.2f", gain.percent) .. "%|r");
+        end
         hasGain = true;
     elseif gain and gain.stat and gain.stat > 0 then
-        badge.text:SetText("|cff00ff00" .. prefix .. string.format("%.1f", gain.stat) .. "|r");
+        badge.text:SetText("|cff00ff00" .. prefix .. "+" .. self:FormatStatGain(gain.stat) .. "|r");
         hasGain = true;
     end
 
@@ -690,10 +720,12 @@ function GoWWishlists:UpdateGainBadge(badge, gain, prefix, report, isCatalystIte
         local metric = (gain.metric and gain.metric ~= "") and gain.metric or "DPS";
         if report and report.source then
             local lines = {};
-            -- Line 1: stat + metric + catalyst suffix
+            -- Line 1: always show both stat and percent when available
             local statLine = "";
-            if gain.stat and gain.stat > 0 then
-                statLine = string.format("+%.1f %s", gain.stat, metric);
+            if gain.stat and gain.stat > 0 and gain.percent and gain.percent > 0 then
+                statLine = string.format("+%s %s (%.2f%%)", self:FormatStatGain(gain.stat), metric, gain.percent);
+            elseif gain.stat and gain.stat > 0 then
+                statLine = string.format("+%s %s", self:FormatStatGain(gain.stat), metric);
             else
                 statLine = string.format("%.2f%% %s", gain.percent, metric);
             end
@@ -729,15 +761,17 @@ function GoWWishlists:UpdateGainBadge(badge, gain, prefix, report, isCatalystIte
             badge.tooltipLines = lines;
             badge.tooltipText = nil;
         else
-            -- Fallback: simple tooltip
+            -- Fallback: simple tooltip — always show both values
             badge.tooltipLines = nil;
             local tipParts = {};
-            if gain.percent and gain.percent > 0 then
+            if gain.stat and gain.stat > 0 and gain.percent and gain.percent > 0 then
+                local catalystSuffix = isCatalystItem and " (Catalyst)" or "";
+                table.insert(tipParts, string.format("+%s %s (%.2f%%)%s", self:FormatStatGain(gain.stat), metric, gain.percent, catalystSuffix));
+            elseif gain.percent and gain.percent > 0 then
                 local catalystSuffix = isCatalystItem and " (Catalyst)" or "";
                 table.insert(tipParts, string.format("%.2f%% %s%s", gain.percent, metric, catalystSuffix));
-            end
-            if gain.stat and gain.stat > 0 then
-                table.insert(tipParts, "+" .. string.format("%.1f", gain.stat) .. " " .. metric);
+            elseif gain.stat and gain.stat > 0 then
+                table.insert(tipParts, "+" .. self:FormatStatGain(gain.stat) .. " " .. metric);
             end
             badge.tooltipText = #tipParts > 0 and table.concat(tipParts, "\n") or nil;
         end

--- a/GoWWishlists.lua
+++ b/GoWWishlists.lua
@@ -518,7 +518,7 @@ function GoWWishlists:GetGainValue(gain)
 end
 
 function GoWWishlists:FormatStatGain(n)
-    return tostring(math.floor(n + 0.5));
+    return string.format("%.1f", n);
 end
 
 function GoWWishlists:GroupAndSortBosses(bossOrder, bossToRaid, bossToJournalId)

--- a/wishlists/browser.lua
+++ b/wishlists/browser.lua
@@ -21,6 +21,27 @@ function GoWWishlists:CreateCompactToggleButton(parent)
     return compactBtn;
 end
 
+function GoWWishlists:CreateGainDisplayToggleButton(parent)
+    local isRaw = self.state.gainDisplayMode == "raw";
+    local gainBtn = L:CreateActionButton(parent, {
+        text = isRaw and "#" or "%",
+        width = 28,
+        tooltip = "Toggle gain display",
+        tooltipSubtext = "Switch between percentage and raw stat value on gain badges",
+        onClick = function() self:ToggleGainDisplayMode() end,
+    });
+
+    local function updateGainBtn()
+        local raw = self.state.gainDisplayMode == "raw";
+        L:SetButtonActive(gainBtn, raw);
+        gainBtn.btnText:SetText(raw and "|cff00ff00#|r" or "%");
+    end
+
+    gainBtn.UpdateState = updateGainBtn;
+    updateGainBtn();
+    return gainBtn;
+end
+
 local function UpdateRosterTabVisibility(self, host)
     local rosterTab = host.rosterTab or host.guildWishlistTab;
     if not rosterTab then return end
@@ -68,6 +89,10 @@ local function InitializeWishlistTabHost(self, host, options)
         options.compactRightOffsetY or 0
     );
 
+    local gainDisplayBtn = self:CreateGainDisplayToggleButton(host);
+    gainDisplayBtn:SetPoint("RIGHT", compactBtn, "LEFT", -4, 0);
+    gainDisplayBtn:SetPoint("TOP", compactBtn, "TOP", 0, 0);
+
     local rosterTab = self:CreateTabButton(host, "|cff00ff00ROSTER|r", 2);
     rosterTab:SetPoint("LEFT", personalTab, "RIGHT", 4, 0);
     rosterTab:SetWidth(options.rosterTabWidth or 90);
@@ -91,6 +116,7 @@ local function InitializeWishlistTabHost(self, host, options)
     local guildPanel = self:Create3PanelLayout(guildContainer);
 
     host.compactBtn = compactBtn;
+    host.gainDisplayBtn = gainDisplayBtn;
     host.wishlistTab = personalTab;
     host.rosterTab = rosterTab;
     host.guildWishlistTab = rosterTab;
@@ -293,8 +319,8 @@ function GoWWishlists:CreateCoreWishlistsFrame(parent)
         tooltipSubtext = "Wishlist data is more than 20 minutes old",
         onClick = function() ReloadUI() end,
     });
-    reloadBtn:SetPoint("RIGHT", container.compactBtn, "LEFT", -4, 0);
-    reloadBtn:SetPoint("TOP", container.compactBtn, "TOP", 0, 0);
+    reloadBtn:SetPoint("RIGHT", container.gainDisplayBtn, "LEFT", -4, 0);
+    reloadBtn:SetPoint("TOP", container.gainDisplayBtn, "TOP", 0, 0);
     reloadBtn:Hide();
     container.reloadBtn = reloadBtn;
 

--- a/wishlists/browser.lua
+++ b/wishlists/browser.lua
@@ -262,8 +262,8 @@ function GoWWishlists:CreateWishlistBrowserFrame()
         tooltipSubtext = "Wishlist data is more than 20 minutes old",
         onClick = function() ReloadUI() end,
     });
-    reloadBtn:SetPoint("RIGHT", frame.compactBtn, "LEFT", -4, 0);
-    reloadBtn:SetPoint("TOP", frame.compactBtn, "TOP", 0, 0);
+    reloadBtn:SetPoint("RIGHT", frame.gainDisplayBtn, "LEFT", -4, 0);
+    reloadBtn:SetPoint("TOP", frame.gainDisplayBtn, "TOP", 0, 0);
     reloadBtn:Hide();
     frame.reloadBtn = reloadBtn;
 

--- a/wishlists/browser.lua
+++ b/wishlists/browser.lua
@@ -22,9 +22,8 @@ function GoWWishlists:CreateCompactToggleButton(parent)
 end
 
 function GoWWishlists:CreateGainDisplayToggleButton(parent)
-    local isRaw = self.state.gainDisplayMode == "raw";
     local gainBtn = L:CreateActionButton(parent, {
-        text = isRaw and "#" or "%",
+        text = "#",
         width = 28,
         tooltip = "Toggle gain display",
         tooltipSubtext = "Switch between percentage and raw stat value on gain badges",
@@ -34,7 +33,7 @@ function GoWWishlists:CreateGainDisplayToggleButton(parent)
     local function updateGainBtn()
         local raw = self.state.gainDisplayMode == "raw";
         L:SetButtonActive(gainBtn, raw);
-        gainBtn.btnText:SetText(raw and "|cff00ff00#|r" or "%");
+        gainBtn.btnText:SetText(raw and "|cff00ff00#|r" or "#");
     end
 
     gainBtn.UpdateState = updateGainBtn;

--- a/wishlists/events.lua
+++ b/wishlists/events.lua
@@ -6,6 +6,7 @@ function GoWWishlists:Initialize()
     if not ns.WISHLISTS then GOW.Logger:Debug("No wishlist data found. Skipping wishlist initialization.") return end
 
     self.state.compactMode = GOW.DB and GOW.DB.profile and GOW.DB.profile.wishlistCompactMode or false;
+    self.state.gainDisplayMode = GOW.DB and GOW.DB.profile and GOW.DB.profile.gainDisplayMode or "percent";
     self:BuildWishlistIndex();
     self:HandleLootDropEvents();
     -- self:HandleLootHistoryEvents();

--- a/wishlists/guild.lua
+++ b/wishlists/guild.lua
@@ -9,8 +9,8 @@ GoWWishlists.constants.GUILD_FILTER_HEIGHT = 26;
 local function GetAverageGainFromMembers(members)
     local sum, count = 0, 0;
     for _, member in ipairs(members or {}) do
-        local gain = member.gain and member.gain.percent;
-        if gain and gain > 0 then
+        local gain = GoWWishlists:GetGainValue(member.gain);
+        if gain > 0 then
             sum = sum + gain;
             count = count + 1;
         end
@@ -222,10 +222,11 @@ function GoWWishlists:PopulateGuildItemRow(row, itemData)
 
     row.infoHover.tipText = itemData.difficulty and ("Difficulty: " .. itemData.difficulty) or nil;
 
-    local totalPercent, gainCount, avgMetric = 0, 0, nil;
+    local totalPercent, totalStat, gainCount, avgMetric = 0, 0, 0, nil;
     for _, m in ipairs(itemData.members) do
         if m.gain and m.gain.percent and m.gain.percent > 0 then
             totalPercent = totalPercent + m.gain.percent;
+            totalStat = totalStat + ((m.gain.stat and m.gain.stat > 0) and m.gain.stat or 0);
             gainCount = gainCount + 1;
             if not avgMetric and m.gain.metric and m.gain.metric ~= "" then
                 avgMetric = m.gain.metric;
@@ -233,7 +234,7 @@ function GoWWishlists:PopulateGuildItemRow(row, itemData)
         end
     end
     if gainCount > 0 then
-        self:UpdateGainBadge(row.gainBadge, { percent = totalPercent / gainCount, metric = avgMetric or "DPS" }, "avg ");
+        self:UpdateGainBadge(row.gainBadge, { percent = totalPercent / gainCount, stat = totalStat / gainCount, metric = avgMetric or "DPS" }, "avg ");
     else
         row.gainBadge:Hide();
     end
@@ -797,8 +798,8 @@ function GoWWishlists:PopulateGuildLootPanel(lootPanel, bossGroups, bossOrder, s
 
     local function buildItemWithMembers(itemData)
         table.sort(itemData.members, function(a, b)
-            local aGain = (a.gain and a.gain.percent) or 0;
-            local bGain = (b.gain and b.gain.percent) or 0;
+            local aGain = self:GetGainValue(a.gain);
+            local bGain = self:GetGainValue(b.gain);
             return aGain > bGain;
         end);
 
@@ -899,8 +900,8 @@ function GoWWishlists:PopulateGuildLootPanel(lootPanel, bossGroups, bossOrder, s
                 local bossGainSum, bossGainCount = 0, 0;
                 for _, itemKey in ipairs(boss.itemOrder) do
                     for _, member in ipairs(boss.items[itemKey].members) do
-                        local gain = member.gain and member.gain.percent;
-                        if gain and gain > 0 then
+                        local gain = self:GetGainValue(member.gain);
+                        if gain > 0 then
                             bossGainSum = bossGainSum + gain;
                             bossGainCount = bossGainCount + 1;
                         end
@@ -1332,8 +1333,8 @@ function GoWWishlists:PopulateGuildPlayerDetail(detailPanel, member, guildRealm)
         end);
     else
         table.sort(memberItems, function(a, b)
-            local aGain = (a.gain and a.gain.percent) or 0;
-            local bGain = (b.gain and b.gain.percent) or 0;
+            local aGain = self:GetGainValue(a.gain);
+            local bGain = self:GetGainValue(b.gain);
             return aGain > bGain;
         end);
     end

--- a/wishlists/personal.lua
+++ b/wishlists/personal.lua
@@ -200,8 +200,8 @@ function GoWWishlists:PopulatePersonalWishlistView(frame)
             end);
         else -- "upgrade"
             table.sort(sortedItems, function(a, b)
-                local aGain = (a.gain and a.gain.percent) or 0;
-                local bGain = (b.gain and b.gain.percent) or 0;
+                local aGain = self:GetGainValue(a.gain);
+                local bGain = self:GetGainValue(b.gain);
                 return aGain > bGain;
             end);
         end


### PR DESCRIPTION
This pull request adds a new "gain display mode" feature, allowing users to toggle between viewing gain badges as percentages or raw stat values throughout the wishlists UI. It introduces a toggle button in the wishlist interface, updates sorting and aggregation logic to respect the selected mode, and ensures gain badges and tooltips consistently reflect the user's preference. Several code paths are updated to use a new helper function for retrieving the correct gain value.

**New Feature: Gain Display Mode Toggle**
- Added a `gainDisplayMode` setting (defaulting to `"percent"`) to user profile and state, and provided a UI toggle button (`gainDisplayBtn`) to switch between percentage and raw stat display for gain badges. The toggle button is integrated into the wishlist browser and core wishlists frame. [[1]](diffhunk://#diff-b125e62b8c0238cc3ad7b6cceb3705945116b050a8e3fe642cb479a32468e61aR30) [[2]](diffhunk://#diff-04fb790e35bd09a2aaf0235561d7fb41a303b60a255eaeda00030691c716f705R24-R43) [[3]](diffhunk://#diff-04fb790e35bd09a2aaf0235561d7fb41a303b60a255eaeda00030691c716f705R91-R94) [[4]](diffhunk://#diff-04fb790e35bd09a2aaf0235561d7fb41a303b60a255eaeda00030691c716f705R118) [[5]](diffhunk://#diff-04fb790e35bd09a2aaf0235561d7fb41a303b60a255eaeda00030691c716f705L296-R322) [[6]](diffhunk://#diff-3354f5960d2fc771e54335135ee39921475087e21790274536c94e1aee761450R9)

**Wishlist Views and Sorting Updates**
- Updated all relevant sorting and aggregation logic (e.g., in personal wishlists, guild loot panels, and player details) to use a new `GetGainValue` helper, which returns either the percent or raw stat value based on the current display mode. [[1]](diffhunk://#diff-d0dc1f2a3063350103f9ea69e757bfb1f924cc928f34511029b5c3c72572b8f7L12-R13) [[2]](diffhunk://#diff-d0dc1f2a3063350103f9ea69e757bfb1f924cc928f34511029b5c3c72572b8f7L800-R802) [[3]](diffhunk://#diff-d0dc1f2a3063350103f9ea69e757bfb1f924cc928f34511029b5c3c72572b8f7L902-R904) [[4]](diffhunk://#diff-d0dc1f2a3063350103f9ea69e757bfb1f924cc928f34511029b5c3c72572b8f7L1335-R1337) [[5]](diffhunk://#diff-80c8776b446da67e572c8112d9c56ed4da3b26fa2728ff767e7c11a69216851cL203-R204)

**Gain Badge and Tooltip Improvements**
- Modified gain badge rendering and tooltips to show the correct value per the selected mode, and improved tooltips to always display both stat and percent values when available for clarity. [[1]](diffhunk://#diff-a6724b251625dbb4617326c7043c179035db2fd7b200bb3f8b6ef40f37137a19R504-R523) [[2]](diffhunk://#diff-a6724b251625dbb4617326c7043c179035db2fd7b200bb3f8b6ef40f37137a19L678-R712) [[3]](diffhunk://#diff-a6724b251625dbb4617326c7043c179035db2fd7b200bb3f8b6ef40f37137a19L693-R728) [[4]](diffhunk://#diff-a6724b251625dbb4617326c7043c179035db2fd7b200bb3f8b6ef40f37137a19L732-R773) [[5]](diffhunk://#diff-d0dc1f2a3063350103f9ea69e757bfb1f924cc928f34511029b5c3c72572b8f7L225-R237)

**UI and State Management**
- Ensured the gain display toggle button updates its state visually and programmatically, and that toggling the mode triggers a refresh of all relevant wishlist views. [[1]](diffhunk://#diff-a6724b251625dbb4617326c7043c179035db2fd7b200bb3f8b6ef40f37137a19R448-R450) [[2]](diffhunk://#diff-a6724b251625dbb4617326c7043c179035db2fd7b200bb3f8b6ef40f37137a19R459-R461) [[3]](diffhunk://#diff-a6724b251625dbb4617326c7043c179035db2fd7b200bb3f8b6ef40f37137a19R504-R523) [[4]](diffhunk://#diff-04fb790e35bd09a2aaf0235561d7fb41a303b60a255eaeda00030691c716f705R24-R43)

**Minor Improvements**
- Normalized console command input to lowercase for consistency.