### PR TITLE
Enhance item ID handling and update display mode UI

### DIFF
--- a/rclc/core.lua
+++ b/rclc/core.lua
@@ -62,7 +62,7 @@ function RCGoW:GetPlayerWish(itemId, playerFullName)
             or (charEntry.realmName and charEntry.realmName:gsub("%s", "") == playerRealm);
         if nameMatch and realmMatch then
             for _, item in ipairs(charEntry.wishlist) do
-                if item.itemId == itemId and not item.isObtained then
+                if (item.itemId == itemId or item.sourceItemId == itemId) and not item.isObtained then
                     table.insert(matches, item);
                 end
             end

--- a/rclc/lootFrame.lua
+++ b/rclc/lootFrame.lua
@@ -30,7 +30,8 @@ local function OnEntryRefreshed(entry)
     local itemId;
     for _, session in ipairs(sessions) do
         if lootTable[session] and lootTable[session].link then
-            itemId = C_Item.GetItemInfoInstant(lootTable[session].link);
+            local link = lootTable[session].link;
+            itemId = C_Item.GetItemInfoInstant(link) or tonumber(link:match("item:(%d+)"));
             if itemId then break end
         end
     end

--- a/rclc/votingFrame.lua
+++ b/rclc/votingFrame.lua
@@ -225,13 +225,23 @@ function GoWVotingColumn:OnSessionChanged(_, session)
     self:ScheduleTimer(RefreshScrollTable, 0.1);
 end
 
-local GOW_ICON_SMALL = "|TInterface\\AddOns\\GuildsOfWoW\\icons\\guilds-of-wow-logo-flag-plain.png:14:14|t";
-local DISPLAY_MODES = { "percent", "value", "tag" };
-local DISPLAY_LABELS = { percent = "Show Value", value = "Show Tag", tag = "Show %" };
+local DISPLAY_MODE_BUTTONS = {
+    { value = "percent", label = "%",   tooltip = "Show % upgrade gain" },
+    { value = "value",   label = "#",   tooltip = "Show raw stat gain" },
+    { value = "tag",     label = "Tag", tooltip = "Show wishlist priority tag" },
+};
 
-local function UpdateToggleLabel(btn)
+local function UpdateModeButtons(buttons)
     local mode = GetDisplayMode();
-    btn:SetText(GOW_ICON_SMALL .. " " .. (DISPLAY_LABELS[mode] or "Show %"));
+    for _, btn in ipairs(buttons) do
+        if btn._gowMode == mode then
+            btn._gowHighlight:Show();
+            btn._gowFs:SetTextColor(1, 0.84, 0);
+        else
+            btn._gowHighlight:Hide();
+            btn._gowFs:SetTextColor(0.85, 0.85, 0.85);
+        end
+    end
 end
 
 function GoWVotingColumn:AddToggleButton()
@@ -259,34 +269,71 @@ function GoWVotingColumn:AddToggleButton()
 
     local parent = frame.content or frame.frame or frame;
 
-    local btn = CreateFrame("Button", nil, parent, "UIPanelButtonTemplate");
-    btn:SetSize(120, 25);
-    btn:SetPoint("RIGHT", anchor, "LEFT", -4, 0);
-    btn:SetFrameStrata("DIALOG");
+    local BTN_W, BORDER = 36, 8;
+    local INSET = BORDER / 2;
+    local BTN_H = rclcBtn:GetHeight() - BORDER;
 
-    UpdateToggleLabel(btn);
+    local groupFrame = CreateFrame("Frame", nil, parent, "BackdropTemplate");
+    groupFrame:SetSize(BTN_W * #DISPLAY_MODE_BUTTONS + BORDER, BTN_H + BORDER);
+    groupFrame:SetPoint("RIGHT", anchor, "LEFT", -4, 0);
+    groupFrame:SetFrameStrata("DIALOG");
+    groupFrame:SetBackdrop({
+        bgFile   = "Interface\\Buttons\\WHITE8X8",
+        edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+        tile = false, edgeSize = BORDER,
+        insets = { left = INSET, right = INSET, top = INSET, bottom = INSET },
+    });
+    groupFrame:SetBackdropColor(0.12, 0.12, 0.12, 0.9);
+    groupFrame:SetBackdropBorderColor(0.5, 0.5, 0.5, 0.9);
 
-    btn:SetScript("OnClick", function()
-        local current = GetDisplayMode();
-        local nextIdx = 1;
-        for i, m in ipairs(DISPLAY_MODES) do
-            if m == current then nextIdx = (i % #DISPLAY_MODES) + 1; break end
+    local buttons = {};
+    for i, opt in ipairs(DISPLAY_MODE_BUTTONS) do
+        local btn = CreateFrame("Button", nil, groupFrame);
+        btn:SetSize(BTN_W, BTN_H);
+        btn:SetPoint("LEFT", groupFrame, "LEFT", INSET + (i - 1) * BTN_W, 0);
+        btn._gowMode = opt.value;
+
+        local hl = btn:CreateTexture(nil, "BACKGROUND");
+        hl:SetAllPoints(btn);
+        hl:SetColorTexture(1, 0.84, 0, 0.15);
+        hl:Hide();
+        btn._gowHighlight = hl;
+
+        local hover = btn:CreateTexture(nil, "HIGHLIGHT");
+        hover:SetAllPoints(btn);
+        hover:SetColorTexture(1, 1, 1, 0.08);
+
+        local fs = btn:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall");
+        fs:SetAllPoints(btn);
+        fs:SetJustifyH("CENTER");
+        fs:SetText(opt.label);
+        btn._gowFs = fs;
+
+        if i > 1 then
+            local div = groupFrame:CreateTexture(nil, "ARTWORK");
+            div:SetSize(1, BTN_H - 6);
+            div:SetPoint("LEFT", groupFrame, "LEFT", INSET + (i - 1) * BTN_W, 0);
+            div:SetColorTexture(0.5, 0.5, 0.5, 0.6);
         end
-        local newMode = DISPLAY_MODES[nextIdx];
-        if GOW.DB then GOW.DB.profile.rclcDisplayMode = newMode end
-        UpdateToggleLabel(btn);
-        RefreshScrollTable();
-    end);
 
-    btn:SetScript("OnEnter", function(self)
-        GameTooltip:SetOwner(self, "ANCHOR_RIGHT");
-        GameTooltip:AddLine("Guilds of WoW", 0.1, 0.8, 0.3);
-        GameTooltip:AddLine("Click to cycle between % gain, raw value, and tag.", 1, 1, 1, true);
-        GameTooltip:Show();
-    end);
-    btn:SetScript("OnLeave", function() GameTooltip:Hide() end);
+        btn:SetScript("OnClick", function()
+            if GOW.DB then GOW.DB.profile.rclcDisplayMode = opt.value end
+            UpdateModeButtons(buttons);
+            RefreshScrollTable();
+        end);
+        btn:SetScript("OnEnter", function(self)
+            GameTooltip:SetOwner(self, "ANCHOR_RIGHT");
+            GameTooltip:AddLine("Guilds of WoW", 0.1, 0.8, 0.3);
+            GameTooltip:AddLine(opt.tooltip, 1, 1, 1, true);
+            GameTooltip:Show();
+        end);
+        btn:SetScript("OnLeave", function() GameTooltip:Hide() end);
 
-    frame._gowToggleBtn = btn;
+        buttons[i] = btn;
+    end
+
+    UpdateModeButtons(buttons);
+    frame._gowToggleBtn = groupFrame;
 end
 
 if RCVotingFrame.frame then

--- a/rclc/votingFrame.lua
+++ b/rclc/votingFrame.lua
@@ -220,6 +220,12 @@ local function RefreshScrollTable()
     end
 end
 
+local function SortScrollTable()
+    if RCVotingFrame.frame and RCVotingFrame.frame.st then
+        RCVotingFrame.frame.st:SortData();
+    end
+end
+
 function GoWVotingColumn:OnSessionChanged(_, session)
     activeSession = session or 1;
     self:ScheduleTimer(RefreshScrollTable, 0.1);
@@ -319,7 +325,7 @@ function GoWVotingColumn:AddToggleButton()
         btn:SetScript("OnClick", function()
             if GOW.DB then GOW.DB.profile.rclcDisplayMode = opt.value end
             UpdateModeButtons(buttons);
-            RefreshScrollTable();
+            SortScrollTable();
         end);
         btn:SetScript("OnEnter", function(self)
             GameTooltip:SetOwner(self, "ANCHOR_RIGHT");
@@ -338,6 +344,7 @@ end
 
 if RCVotingFrame.frame then
     RCVotingFrame.frame:HookScript("OnShow", function()
+        if GOW.DB and GOW.DB.profile.showRCLCWishlist == false then return end
         InsertGoWColumn();
         GoWVotingColumn:ScheduleTimer(RefreshScrollTable, 0.1);
     end);

--- a/rclc/votingFrame.lua
+++ b/rclc/votingFrame.lua
@@ -25,7 +25,7 @@ local function GetActiveItemId()
     if not lootTable or not lootTable[activeSession] then return nil end
     local link = lootTable[activeSession].link;
     if not link then return nil end
-    return C_Item.GetItemInfoInstant(link);
+    return C_Item.GetItemInfoInstant(link) or tonumber(link:match("item:(%d+)"));
 end
 
 local function RenderWishCell(rowFrame, cellFrame, data, cols, row, realRow, column, fShow, st)
@@ -214,14 +214,15 @@ function GoWVotingColumn:OnInitialize()
     self:ScheduleTimer("AddToggleButton", 1);
 end
 
-function GoWVotingColumn:OnSessionChanged(_, session)
-    activeSession = session or 1;
-end
-
 local function RefreshScrollTable()
     if RCVotingFrame.frame and RCVotingFrame.frame.st then
         RCVotingFrame.frame.st:Refresh();
     end
+end
+
+function GoWVotingColumn:OnSessionChanged(_, session)
+    activeSession = session or 1;
+    self:ScheduleTimer(RefreshScrollTable, 0.1);
 end
 
 local GOW_ICON_SMALL = "|TInterface\\AddOns\\GuildsOfWoW\\icons\\guilds-of-wow-logo-flag-plain.png:14:14|t";
@@ -289,5 +290,8 @@ function GoWVotingColumn:AddToggleButton()
 end
 
 if RCVotingFrame.frame then
-    RCVotingFrame.frame:HookScript("OnShow", InsertGoWColumn);
+    RCVotingFrame.frame:HookScript("OnShow", function()
+        InsertGoWColumn();
+        GoWVotingColumn:ScheduleTimer(RefreshScrollTable, 0.1);
+    end);
 end


### PR DESCRIPTION
This pull request improves item ID handling and enhances the voting frame UI for display mode selection in the addon. The most significant changes ensure more robust item ID extraction and introduce a clearer, more user-friendly way to switch between display modes in the voting interface.

**Item ID Handling Improvements:**
* Updated item ID extraction logic in `lootFrame.lua` and `votingFrame.lua` to fall back to parsing the item link directly if the standard API call fails, improving compatibility with non-standard or un-cached items. [[1]](diffhunk://#diff-1967309d4ab62c8c99067c6696dc1e315c66978e3e172a49401eef548fd424a9L33-R34) [[2]](diffhunk://#diff-7b01fec460d329c71ca26a775899a6b93a0558f51eb699aae651f591cb2807c1L28-R28)
* Enhanced wishlist matching in `core.lua` to consider both `itemId` and `sourceItemId`, increasing the accuracy of player wish lookups.

**Voting Frame UI Enhancements:**
* Refactored the display mode toggle in the voting frame: replaced the single cycle button with a group of clearly labeled buttons for each display mode (percent, value, tag), each with its own tooltip and visual highlight for the selected mode. This makes it easier for users to switch and understand the current display. [[1]](diffhunk://#diff-7b01fec460d329c71ca26a775899a6b93a0558f51eb699aae651f591cb2807c1L217-R244) [[2]](diffhunk://#diff-7b01fec460d329c71ca26a775899a6b93a0558f51eb699aae651f591cb2807c1L261-R343)
* Improved the refresh logic when the session changes or the voting frame is shown, ensuring the UI updates promptly and accurately. [[1]](diffhunk://#diff-7b01fec460d329c71ca26a775899a6b93a0558f51eb699aae651f591cb2807c1L217-R244) [[2]](diffhunk://#diff-7b01fec460d329c71ca26a775899a6b93a0558f51eb699aae651f591cb2807c1L261-R343)